### PR TITLE
Add Rational type and integer protocol conformances

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,22 @@
 # NumericAnnex
 
 NumericAnnex supplements the numeric facilities provided in the Swift standard
-library. It is in the earliest stages of development and most definitely not
-production-ready at this time.
+library. It is in the earliest stages of development and not production-ready at
+this time.
+
+At present, NumericAnnex requires the latest mainline development (master)
+branch of Swift because the revised numeric protocols are not yet available in
+pre-release or release toolchains.
 
 ### Currently implemented
 
 - [x] `Math` and `FloatingPointMath` protocols
 - [x] `Complex`
+- [x] `Rational`
 
 ### Near-term goals
 
 - [ ] Add many more tests
-- [ ] Add `Rational`
 
 ### Later goals
 

--- a/Sources/Complex+Math.swift
+++ b/Sources/Complex+Math.swift
@@ -59,10 +59,8 @@ extension Complex : Numeric {
   @_transparent // @_inlineable
   public static func *= (lhs: inout Complex, rhs: Complex) {
     let t = lhs.real
-    lhs.real *= rhs.real
-    lhs.real -= lhs.imaginary * rhs.imaginary
-    lhs.imaginary *= rhs.real
-    lhs.imaginary += t * rhs.imaginary
+    lhs.real = lhs.real * rhs.real - lhs.imaginary * rhs.imaginary
+    lhs.imaginary = t * rhs.imaginary + lhs.imaginary * rhs.real
   }
 }
 
@@ -122,6 +120,23 @@ extension Complex : Math {
         (lhs.imaginary * rhs.real - lhs.real * rhs.imaginary) / denominator
     )
     */
+  }
+
+  @_transparent // @_inlineable
+  public static func /= (lhs: inout Complex, rhs: Complex) {
+    // Prevent avoidable overflow; see Numerical Recipes.
+    let t = lhs.real
+    if rhs.real.magnitude >= rhs.imaginary.magnitude {
+      let ratio = rhs.imaginary / rhs.real
+      let denominator = rhs.real + rhs.imaginary * ratio
+      lhs.real = (lhs.real + lhs.imaginary * ratio) / denominator
+      lhs.imaginary = (lhs.imaginary - t * ratio) / denominator
+    } else {
+      let ratio = rhs.real / rhs.imaginary
+      let denominator = rhs.real * ratio + rhs.imaginary
+      lhs.real = (lhs.real * ratio + lhs.imaginary) / denominator
+      lhs.imaginary = (lhs.imaginary * ratio - t) / denominator
+    }
   }
 
   @_transparent // @_inlineable

--- a/Sources/Complex+Math.swift
+++ b/Sources/Complex+Math.swift
@@ -471,6 +471,12 @@ extension Complex : Math {
   }
 }
 
+/// Returns the absolute value (magnitude, modulus) of `z`.
+@_transparent
+public func abs<T>(_ z: Complex<T>) -> Complex<T> {
+  return Complex(real: z.magnitude)
+}
+
 /// Returns the square root of `z`.
 @_transparent
 public func sqrt<T>(_ z: Complex<T>) -> Complex<T> {

--- a/Sources/Complex.swift
+++ b/Sources/Complex.swift
@@ -297,6 +297,13 @@ extension Complex {
     return T.hypot(real, imaginary)
   }
 
+  /// The polar coordinates representing this value, equivalent to
+  /// `(r: magnitude, theta: argument)`.
+  @_transparent // @_inlineable
+  public var polar: (r: T, theta: T) {
+    return (r: magnitude, theta: argument)
+  }
+
   /// The squared magnitude (field norm, absolute square) of this value.
   ///
   /// This is less costly to compute than `magnitude` and, in some cases, can be
@@ -309,21 +316,14 @@ extension Complex {
     return real * real + imaginary * imaginary
   }
 
-  /// The complex conjugate of this value, obtained by reversing the sign of the
-  /// imaginary component.
+  /// Returns the complex conjugate of this value, obtained by reversing the
+  /// sign of the imaginary component.
   @_transparent // @_inlineable
   public func conjugate() -> Complex {
     return Complex(real: real, imaginary: -imaginary)
   }
 
-  /// The polar coordinates representing this value, equivalent to
-  /// `(magnitude, argument)`.
-  @_transparent // @_inlineable
-  public func polar() -> (r: T, theta: T) {
-    return (magnitude, argument)
-  }
-
-  /// The projection of this value onto the Riemann sphere.
+  /// Returns the projection of this value onto the Riemann sphere.
   ///
   /// For most values `z`, `z.projection() == z`. The projection of any complex
   /// infinity is positive real infinity. The sign of the imaginary component is
@@ -339,7 +339,7 @@ extension Complex {
     return self
   }
 
-  /// The reciprocal (multiplicative inverse) of this value.
+  /// Returns the reciprocal (multiplicative inverse) of this value.
   @_transparent // @_inlineable
   public func reciprocal() -> Complex {
     let denominator = squaredMagnitude
@@ -388,9 +388,3 @@ extension Complex : Hashable {
 
 public typealias Complex64 = Complex<Float>
 public typealias Complex128 = Complex<Double>
-
-/// Returns the absolute value (magnitude, modulus) of `z`.
-@_transparent
-public func abs<T>(_ z: Complex<T>) -> Complex<T> {
-  return Complex(real: z.magnitude)
-}

--- a/Sources/Complex.swift
+++ b/Sources/Complex.swift
@@ -35,16 +35,6 @@ public struct Complex<
 }
 
 extension Complex {
-  /// Creates a new value from the given real component.
-  ///
-  /// - Parameters:
-  ///   - real: The new value's real component.
-  @_transparent // @_inlineable
-  init(_ real: T) {
-    self.real = real
-    self.imaginary = 0
-  }
-
   /// Creates a new value from the given real component, rounded to the closest
   /// possible representation.
   ///
@@ -185,8 +175,36 @@ extension Complex {
     self.imaginary = 0
   }
 
-  // FIXME: If protocol requirements are added to FloatingPoint
-  // add init(_: Float) and friends, as well as init?(exactly:).
+  // FIXME: If corresponding requirements are added to FloatingPoint
+  // add init<U : Integer>(_: U) as well as init?<U : Integer>(exactly: U).
+}
+
+extension Complex where T : BinaryFloatingPoint {
+  /// Creates a new value from the given real component, rounded to the closest
+  /// possible representation.
+  ///
+  /// - Parameters:
+  ///   - real: The value to convert to a real component of type `T`.
+  @_transparent // @_inlineable
+  public init(_ real: Float) {
+    self.real = T(real)
+    self.imaginary = 0
+  }
+
+  /// Creates a new value from the given real component, rounded to the closest
+  /// possible representation.
+  ///
+  /// - Parameters:
+  ///   - real: The value to convert to a real component of type `T`.
+  @_transparent // @_inlineable
+  public init(_ real: Double) {
+    self.real = T(real)
+    self.imaginary = 0
+  }
+
+  // FIXME: If corresponding requirements are added to BinaryFloatingPoint
+  // add init<U : BinaryFloatingPoint>(_: U) as well as
+  // init?<U : BinaryFloatingPoint>(exactly: U).
 }
 
 extension Complex {
@@ -362,7 +380,7 @@ extension Complex : Equatable {
 }
 
 extension Complex : Hashable {
-  @_transparent // @_inlineable
+  // @_transparent // @_inlineable
   public var hashValue: Int {
     return _fnv1a(real, imaginary)
   }

--- a/Sources/Factoring.swift
+++ b/Sources/Factoring.swift
@@ -1,0 +1,116 @@
+//
+//  Factoring.swift
+//  NumericAnnex
+//
+//  Created by Xiaodi Wu on 4/15/17.
+//
+
+extension _Integer where Magnitude : _UnsignedInteger {
+  /// The greatest common denominator of `a` and `b`.
+  public static func gcd(_ a: Self, _ b: Self) -> Self {
+    var a = a.magnitude, b = b.magnitude
+
+    if a == 0 { return Self(b) } // gcd(0, b) == b
+    if b == 0 { return Self(a) } // gcd(a, 0) == a
+
+    var shift = 0 as Magnitude
+    while ((a | b) & 1) == 0 {
+      a >>= 1
+      b >>= 1
+      shift += 1 as Magnitude
+    }
+    // Now, shift is equal to log2(k), where k is the greatest power of 2
+    // dividing a and b.
+
+    while (a & 1) == 0 { a >>= 1 } // Now, a is odd.
+    repeat {
+      while (b & 1) == 0 { b >>= 1 } // Now, b is odd.
+      if a > b { swap(&a, &b) } // Now, a < b.
+      b -= a
+    } while b != 0
+
+    // Restore common factors of 2.
+    return Self(a << shift)
+  }
+}
+
+// -----------------------------------------------------------------------------
+// FIXME: Remove the following protocols after new integer protocols are landed
+// -----------------------------------------------------------------------------
+public protocol _Integer : Integer {
+  associatedtype Magnitude : Equatable, ExpressibleByIntegerLiteral, Comparable
+  var magnitude: Magnitude { get }
+  init(_: Magnitude)
+
+  static func >> (_: Self, _: Self) -> Self
+  static func << (_: Self, _: Self) -> Self
+  static func >>= (_: inout Self, _: Self)
+  static func <<= (_: inout Self, _: Self)
+}
+
+public protocol _UnsignedInteger : _Integer, UnsignedInteger { }
+
+extension UInt : _UnsignedInteger {
+  public var magnitude: UInt { return self }
+}
+
+extension UInt8 : _UnsignedInteger {
+  public var magnitude: UInt8 { return self }
+}
+
+extension UInt16 : _UnsignedInteger {
+  public var magnitude: UInt16 { return self }
+}
+
+extension UInt32 : _UnsignedInteger {
+  public var magnitude: UInt32 { return self }
+}
+
+extension UInt64 : _UnsignedInteger {
+  public var magnitude: UInt64 { return self }
+}
+
+public protocol _SignedInteger : _Integer, SignedInteger {
+  mutating func negate()
+}
+
+extension _SignedInteger {
+  public mutating func negate() {
+    self = 0 - self
+  }
+}
+
+extension Int : _SignedInteger {
+  public var magnitude: UInt {
+    let base = UInt(bitPattern: self)
+    return self < 0 ? ~base + 1 : base
+  }
+}
+
+extension Int8 : _SignedInteger {
+  public var magnitude: UInt8 {
+    let base = UInt8(bitPattern: self)
+    return self < 0 ? ~base + 1 : base
+  }
+}
+
+extension Int16 : _SignedInteger {
+  public var magnitude: UInt16 {
+    let base = UInt16(bitPattern: self)
+    return self < 0 ? ~base + 1 : base
+  }
+}
+
+extension Int32 : _SignedInteger {
+  public var magnitude: UInt32 {
+    let base = UInt32(bitPattern: self)
+    return self < 0 ? ~base + 1 : base
+  }
+}
+
+extension Int64 : _SignedInteger {
+  public var magnitude: UInt64 {
+    let base = UInt64(bitPattern: self)
+    return self < 0 ? ~base + 1 : base
+  }
+}

--- a/Sources/Factoring.swift
+++ b/Sources/Factoring.swift
@@ -5,19 +5,18 @@
 //  Created by Xiaodi Wu on 4/15/17.
 //
 
-extension _Integer where Magnitude : _UnsignedInteger {
+extension _UnsignedInteger {
   /// The greatest common denominator of `a` and `b`.
   public static func gcd(_ a: Self, _ b: Self) -> Self {
-    var a = a.magnitude, b = b.magnitude
+    if a == 0 { return b } // gcd(0, b) == b
+    if b == 0 { return a } // gcd(a, 0) == a
 
-    if a == 0 { return Self(b) } // gcd(0, b) == b
-    if b == 0 { return Self(a) } // gcd(a, 0) == a
+    var a = a, b = b, shift = 0 as Self
 
-    var shift = 0 as Magnitude
     while ((a | b) & 1) == 0 {
       a >>= 1
       b >>= 1
-      shift += 1 as Magnitude
+      shift += 1 as Self
     }
     // Now, shift is equal to log2(k), where k is the greatest power of 2
     // dividing a and b.
@@ -30,7 +29,13 @@ extension _Integer where Magnitude : _UnsignedInteger {
     } while b != 0
 
     // Restore common factors of 2.
-    return Self(a << shift)
+    return a << shift
+  }
+
+  /// The lowest common multiple of `a` and `b`.
+  public static func lcm(_ a: Self, _ b: Self) -> Self {
+    if a == 0 || b == 0 { return 0 }
+    return a / Self.gcd(a, b) * b
   }
 }
 

--- a/Sources/Factoring.swift
+++ b/Sources/Factoring.swift
@@ -6,7 +6,7 @@
 //
 
 extension UnsignedInteger {
-  /// The greatest common denominator of `a` and `b`.
+  /// Returns the greatest common denominator of `a` and `b`.
   // @_transparent // @_inlineable
   public static func gcd(_ a: Self, _ b: Self) -> Self {
     if a == 0 { return b } // gcd(0, b) == b
@@ -33,7 +33,7 @@ extension UnsignedInteger {
     return a &<< shift
   }
 
-  /// The lowest common multiple of `a` and `b`.
+  /// Returns the lowest common multiple of `a` and `b`.
   // @_transparent // @_inlineable
   public static func lcm(_ a: Self, _ b: Self) -> Self {
     if a == 0 || b == 0 { return 0 }
@@ -42,7 +42,8 @@ extension UnsignedInteger {
 }
 
 extension UnsignedInteger where Self : FixedWidthInteger {
-  /// The high and low parts of the lowest common multiple of `a` and `b`.
+  /// Returns the high and low parts of the lowest common multiple of `a` and
+  /// `b` computed using full-width operations.
   // @_transparent // @_inlineable
   public static func lcmFullWidth(_ a: Self, _ b: Self)
     -> (high: Self, low: Self.Magnitude) {

--- a/Sources/Factoring.swift
+++ b/Sources/Factoring.swift
@@ -5,7 +5,7 @@
 //  Created by Xiaodi Wu on 4/15/17.
 //
 
-extension _UnsignedInteger {
+extension UnsignedInteger {
   /// The greatest common denominator of `a` and `b`.
   public static func gcd(_ a: Self, _ b: Self) -> Self {
     if a == 0 { return b } // gcd(0, b) == b
@@ -14,22 +14,22 @@ extension _UnsignedInteger {
     var a = a, b = b, shift = 0 as Self
 
     while ((a | b) & 1) == 0 {
-      a >>= 1
-      b >>= 1
-      shift += 1 as Self
+      a &>>= 1
+      b &>>= 1
+      shift += 1
     }
     // Now, shift is equal to log2(k), where k is the greatest power of 2
     // dividing a and b.
 
-    while (a & 1) == 0 { a >>= 1 } // Now, a is odd.
+    while (a & 1) == 0 { a &>>= 1 } // Now, a is odd.
     repeat {
-      while (b & 1) == 0 { b >>= 1 } // Now, b is odd.
+      while (b & 1) == 0 { b &>>= 1 } // Now, b is odd.
       if a > b { swap(&a, &b) } // Now, a < b.
       b -= a
     } while b != 0
 
     // Restore common factors of 2.
-    return a << shift
+    return a &<< shift
   }
 
   /// The lowest common multiple of `a` and `b`.
@@ -38,7 +38,7 @@ extension _UnsignedInteger {
     return a / Self.gcd(a, b) * b
   }
 }
-
+/*
 // -----------------------------------------------------------------------------
 // FIXME: Remove the following protocols after new integer protocols are landed
 // -----------------------------------------------------------------------------
@@ -119,3 +119,4 @@ extension Int64 : _SignedInteger {
     return self < 0 ? ~base + 1 : base
   }
 }
+*/

--- a/Sources/Factoring.swift
+++ b/Sources/Factoring.swift
@@ -38,6 +38,16 @@ extension UnsignedInteger {
     return a / Self.gcd(a, b) * b
   }
 }
+
+extension UnsignedInteger where Self : FixedWidthInteger {
+  /// The high and low parts of the lowest common multiple of `a` and `b`.
+  public static func lcmFullWidth(_ a: Self, _ b: Self)
+    -> (high: Self, low: Self.Magnitude) {
+    if a == 0 || b == 0 { return (0, 0) }
+    return (a / Self.gcd(a, b)).multipliedFullWidth(by: b)
+  }
+}
+
 /*
 // -----------------------------------------------------------------------------
 // FIXME: Remove the following protocols after new integer protocols are landed

--- a/Sources/Factoring.swift
+++ b/Sources/Factoring.swift
@@ -7,6 +7,7 @@
 
 extension UnsignedInteger {
   /// The greatest common denominator of `a` and `b`.
+  // @_transparent // @_inlineable
   public static func gcd(_ a: Self, _ b: Self) -> Self {
     if a == 0 { return b } // gcd(0, b) == b
     if b == 0 { return a } // gcd(a, 0) == a
@@ -33,6 +34,7 @@ extension UnsignedInteger {
   }
 
   /// The lowest common multiple of `a` and `b`.
+  // @_transparent // @_inlineable
   public static func lcm(_ a: Self, _ b: Self) -> Self {
     if a == 0 || b == 0 { return 0 }
     return a / Self.gcd(a, b) * b
@@ -41,92 +43,10 @@ extension UnsignedInteger {
 
 extension UnsignedInteger where Self : FixedWidthInteger {
   /// The high and low parts of the lowest common multiple of `a` and `b`.
+  // @_transparent // @_inlineable
   public static func lcmFullWidth(_ a: Self, _ b: Self)
     -> (high: Self, low: Self.Magnitude) {
     if a == 0 || b == 0 { return (0, 0) }
     return (a / Self.gcd(a, b)).multipliedFullWidth(by: b)
   }
 }
-
-/*
-// -----------------------------------------------------------------------------
-// FIXME: Remove the following protocols after new integer protocols are landed
-// -----------------------------------------------------------------------------
-public protocol _Integer : Integer {
-  associatedtype Magnitude : Equatable, ExpressibleByIntegerLiteral, Comparable
-  var magnitude: Magnitude { get }
-  init(_: Magnitude)
-
-  static func >> (_: Self, _: Self) -> Self
-  static func << (_: Self, _: Self) -> Self
-  static func >>= (_: inout Self, _: Self)
-  static func <<= (_: inout Self, _: Self)
-}
-
-public protocol _UnsignedInteger : _Integer, UnsignedInteger { }
-
-extension UInt : _UnsignedInteger {
-  public var magnitude: UInt { return self }
-}
-
-extension UInt8 : _UnsignedInteger {
-  public var magnitude: UInt8 { return self }
-}
-
-extension UInt16 : _UnsignedInteger {
-  public var magnitude: UInt16 { return self }
-}
-
-extension UInt32 : _UnsignedInteger {
-  public var magnitude: UInt32 { return self }
-}
-
-extension UInt64 : _UnsignedInteger {
-  public var magnitude: UInt64 { return self }
-}
-
-public protocol _SignedInteger : _Integer, SignedInteger {
-  mutating func negate()
-}
-
-extension _SignedInteger {
-  public mutating func negate() {
-    self = 0 - self
-  }
-}
-
-extension Int : _SignedInteger {
-  public var magnitude: UInt {
-    let base = UInt(bitPattern: self)
-    return self < 0 ? ~base + 1 : base
-  }
-}
-
-extension Int8 : _SignedInteger {
-  public var magnitude: UInt8 {
-    let base = UInt8(bitPattern: self)
-    return self < 0 ? ~base + 1 : base
-  }
-}
-
-extension Int16 : _SignedInteger {
-  public var magnitude: UInt16 {
-    let base = UInt16(bitPattern: self)
-    return self < 0 ? ~base + 1 : base
-  }
-}
-
-extension Int32 : _SignedInteger {
-  public var magnitude: UInt32 {
-    let base = UInt32(bitPattern: self)
-    return self < 0 ? ~base + 1 : base
-  }
-}
-
-extension Int64 : _SignedInteger {
-  public var magnitude: UInt64 {
-    let base = UInt64(bitPattern: self)
-    return self < 0 ? ~base + 1 : base
-  }
-}
-*/

--- a/Sources/FloatingPointMath.swift
+++ b/Sources/FloatingPointMath.swift
@@ -11,7 +11,7 @@ import Glibc
 import Darwin
 #endif
 
-public protocol FloatingPointMath : Math, FloatingPoint, Hashable {
+public protocol FloatingPointMath : Math, FloatingPoint /*, Hashable */ {
   /// Returns the hypotenuse of a right-angle triangle with legs (catheti) of
   /// length `x` and `y`, preventing avoidable arithmetic overflow and
   /// underflow. The return value is the square root of the sum of squares of

--- a/Sources/Math.swift
+++ b/Sources/Math.swift
@@ -6,7 +6,7 @@
 //
 
 public protocol Math
-  : Equatable, ExpressibleByIntegerLiteral/*, SignedNumeric */ {
+  : /* Equatable, ExpressibleByIntegerLiteral, */ SignedNumeric {
   /// The mathematical constant pi (_π_).
   ///
   /// This value should be rounded toward zero to keep user computations with
@@ -21,12 +21,14 @@ public protocol Math
   /// The mathematical constant phi (_φ_), or golden ratio.
   static var phi: Self { get }
 
+  /*
   // ---------------------------------------------------------------------------
   // FIXME: Remove the following three requirements after Numeric conformance
   static func + (_: Self, _: Self) -> Self
   static func - (_: Self, _: Self) -> Self
   static func * (_: Self, _: Self) -> Self
   // ---------------------------------------------------------------------------
+  */
 
   /// Returns the quotient obtained by dividing the first value by the second,
   /// rounded to a representable value.

--- a/Sources/Math.swift
+++ b/Sources/Math.swift
@@ -21,15 +21,6 @@ public protocol Math
   /// The mathematical constant phi (_φ_), or golden ratio.
   static var phi: Self { get }
 
-  /*
-  // ---------------------------------------------------------------------------
-  // FIXME: Remove the following three requirements after Numeric conformance
-  static func + (_: Self, _: Self) -> Self
-  static func - (_: Self, _: Self) -> Self
-  static func * (_: Self, _: Self) -> Self
-  // ---------------------------------------------------------------------------
-  */
-
   /// Returns the quotient obtained by dividing the first value by the second,
   /// rounded to a representable value.
   ///
@@ -37,6 +28,8 @@ public protocol Math
   ///   - lhs: The value to divide.
   ///   - rhs: The value by which to divide `lhs`.
   static func / (lhs: Self, rhs: Self) -> Self
+
+  // TODO: `/=`
 
   /// Returns the natural exponential of the value, rounded to a representable
   /// value.

--- a/Sources/Rational+SignedNumeric.swift
+++ b/Sources/Rational+SignedNumeric.swift
@@ -20,8 +20,7 @@ extension Rational : Numeric {
 
   @_transparent // @_inlineable
   public static func + (lhs: Rational, rhs: Rational) -> Rational {
-    if lhs.isNaN { return .nan }
-    if rhs.isNaN { return .nan }
+    if lhs.isNaN || rhs.isNaN { return .nan }
     if lhs.isInfinite {
       return rhs.isInfinite && lhs.sign != rhs.sign ? .nan : lhs
     }
@@ -46,6 +45,20 @@ extension Rational : Numeric {
 
   @_transparent // @_inlineable
   public static func * (lhs: Rational, rhs: Rational) -> Rational {
+    if lhs.isNaN || rhs.isNaN { return .nan }
+    if lhs.isInfinite {
+      if rhs.isZero { return .nan }
+      return lhs.sign != rhs.sign
+        ? lhs.numerator < 0 ? lhs : -lhs
+        : lhs.numerator < 0 ? -lhs : lhs
+    }
+    if rhs.isInfinite {
+      if lhs.isZero { return .nan }
+      return lhs.sign != rhs.sign
+        ? rhs.numerator < 0 ? rhs : -rhs
+        : rhs.numerator < 0 ? -rhs : rhs
+    }
+    
     let lnm = lhs.numerator.magnitude, ldm = lhs.denominator.magnitude
     let rnm = rhs.numerator.magnitude, rdm = rhs.denominator.magnitude
 
@@ -60,15 +73,11 @@ extension Rational : Numeric {
 
     if lhs.sign == rhs.sign {
       return Rational(
-        numerator: T(lnm / a) * T(rnm / b), denominator: T(ldm / b) * T(rdm / a)
+        numerator: T(lnm / a * (rnm / b)), denominator: T(ldm / b * (rdm / a))
       )
     }
     return Rational(
-      // Note that computing `-T(lnm / a) * T(rnm / b)` permits the numerator to
-      // be equal to `T.min` if `T` is a signed fixed-width integer type, but
-      // computing `-T((lnm / a) * (rnm / b))` does not, as `-T.min` is not
-      // representable as a `T`.
-      numerator: -T(lnm / a) * T(rnm / b), denominator: T(ldm / b) * T(rdm / a)
+      numerator: -T(lnm / a * (rnm / b)), denominator: T(ldm / b * (rdm / a))
     )
   }
 

--- a/Sources/Rational+SignedNumeric.swift
+++ b/Sources/Rational+SignedNumeric.swift
@@ -39,7 +39,7 @@ extension Rational : Numeric {
     case (.minus, .minus):
       n = -T(a * lhs.numerator.magnitude) - T(b * rhs.numerator.magnitude)
     }
-    return Rational(numerator: n, denominator: d)._canonicalized()
+    return Rational(numerator: n, denominator: d).canonical
   }
 
   // @_transparent // @_inlineable
@@ -120,7 +120,7 @@ extension Rational where T.Magnitude : FixedWidthInteger {
     let lcm = T.Magnitude.lcmFullWidth(ldm, rdm)
     let a = ldm.magnitude.dividingFullWidth(lcm)
     let b = rdm.magnitude.dividingFullWidth(lcm)
-    // FIXME: Complete the rest of this algorithm.
+    // TODO: Complete the rest of this algorithm.
   }
   */
 }
@@ -155,6 +155,24 @@ extension Rational {
 
   // TODO: `%`
 
+  /// Returns this value rounded to an integral value using the specified
+  /// rounding rule.
+  ///
+  /// ```swift
+  /// let x = 7 / 2 as Rational<Int>
+  /// print(x.rounded()) // Prints "4"
+  /// print(x.rounded(.towardZero)) // Prints "3"
+  /// print(x.rounded(.up)) // Prints "4"
+  /// print(x.rounded(.down)) // Prints "3"
+  /// ```
+  ///
+  /// See the `FloatingPointRoundingRule` enumeration for more information about
+  /// the available rounding rules.
+  ///
+  /// - Parameters:
+  ///   - rule: The rounding rule to use.
+  ///
+  /// - SeeAlso: `round(_:)`, `FloatingPointRoundingRule`
   @_transparent // @_inlineable
   public func rounded(
     _ rule: RationalRoundingRule = .toNearestOrAwayFromZero
@@ -164,6 +182,29 @@ extension Rational {
     return t
   }
 
+  /// Rounds the value to an integral value using the specified rounding rule.
+  ///
+  /// ```swift
+  /// var x = 7 / 2 as Rational<Int>
+  /// x.round() // x == 4
+  ///
+  /// var x = 7 / 2 as Rational<Int>
+  /// x.round(.towardZero) // x == 3
+  ///
+  /// var x = 7 / 2 as Rational<Int>
+  /// x.round(.up) // x == 4
+  ///
+  /// var x = 7 / 2 as Rational<Int>
+  /// x.round(.down) // x == 3
+  /// ```
+  ///
+  /// See the `FloatingPointRoundingRule` enumeration for more information about
+  /// the available rounding rules.
+  ///
+  /// - Parameters:
+  ///   - rule: The rounding rule to use.
+  ///
+  /// - SeeAlso: `round(_:)`, `FloatingPointRoundingRule`
   @_transparent // @_inlineable
   public mutating func round(
     _ rule: RationalRoundingRule = .toNearestOrAwayFromZero
@@ -206,21 +247,32 @@ extension Rational {
   }
 }
 
+/// Returns the absolute value (magnitude) of `x`.
+@_transparent
+public func abs<T>(_ x: Rational<T>) -> Rational<T> {
+  return x.magnitude
+}
+
+/// Returns the closest integral value greater than or equal to `x`.
 @_transparent
 public func ceil<T>(_ x: Rational<T>) -> Rational<T> {
   return x.rounded(.up)
 }
 
+/// Returns the closest integral value less than or equal to `x`.
 @_transparent
 public func floor<T>(_ x: Rational<T>) -> Rational<T> {
   return x.rounded(.down)
 }
 
+/// Returns the closest integral value; if two values are equally close, returns
+/// the one with greater magnitude.
 @_transparent
 public func round<T>(_ x: Rational<T>) -> Rational<T> {
   return x.rounded()
 }
 
+/// Returns the closest integral value with magnitude less than or equal to `x`.
 @_transparent
 public func trunc<T>(_ x: Rational<T>) -> Rational<T> {
   return x.rounded(.towardZero)

--- a/Sources/Rational+SignedNumeric.swift
+++ b/Sources/Rational+SignedNumeric.swift
@@ -5,13 +5,44 @@
 //  Created by Xiaodi Wu on 4/15/17.
 //
 
-extension Rational /* : Numeric */ {
+extension Rational : Numeric {
+  @_transparent // @_inlineable
+  public init?<U>(exactly source: U) where U : BinaryInteger {
+    guard let t = T(exactly: source) else { return nil }
+    self.numerator = t
+    self.denominator = 1
+  }
+
   @_transparent // @_inlineable
   public var magnitude: Rational {
     return sign == .minus ? -self : self
   }
 
-  // TODO: `+`, `-`
+  @_transparent // @_inlineable
+  public static func + (lhs: Rational, rhs: Rational) -> Rational {
+    if lhs.isNaN { return .nan }
+    if rhs.isNaN { return .nan }
+    if lhs.isInfinite {
+      return rhs.isInfinite && lhs.sign != rhs.sign ? .nan : lhs
+    }
+    if rhs.isInfinite { return rhs }
+
+    // FIXME: This could use some improvement and needs testing.
+    let ld = lhs.denominator
+    let rd = rhs.denominator
+    let lcm = T(T.Magnitude.lcm(ld.magnitude, rd.magnitude))
+    let a = lcm / (ld < 0 ? -ld : ld)
+    let b = lcm / (rd < 0 ? -rd : rd)
+    return Rational(
+      numerator: a * lhs.numerator + b * rhs.numerator,
+      denominator: lcm
+    )._canonicalized()
+  }
+
+  @_transparent // @_inlineable
+  public static func - (lhs: Rational, rhs: Rational) -> Rational {
+    return lhs + (-rhs)
+  }
 
   @_transparent // @_inlineable
   public static func * (lhs: Rational, rhs: Rational) -> Rational {
@@ -40,9 +71,50 @@ extension Rational /* : Numeric */ {
       numerator: -T(lnm / a) * T(rnm / b), denominator: T(ldm / b) * T(rdm / a)
     )
   }
+
+  // @_transparent // @_inlineable
+  public static func += (lhs: inout Rational, rhs: Rational) {
+    // FIXME: Implement something better.
+    lhs = lhs + rhs
+  }
+
+  // @_transparent // @_inlineable
+  public static func -= (lhs: inout Rational, rhs: Rational) {
+    // FIXME: Implement something better.
+    lhs = lhs - rhs
+  }
+
+  // @_transparent // @_inlineable
+  public static func *= (lhs: inout Rational, rhs: Rational) {
+    // FIXME: Implement something better.
+    lhs = lhs * rhs
+  }
 }
 
-extension Rational /* : SignedNumeric */ {
+extension Rational where T.Magnitude : FixedWidthInteger {
+  /*
+  @_transparent // @_inlineable
+  public static func + (lhs: Rational, rhs: Rational) -> Rational {
+    if lhs.isNaN { return .nan }
+    if rhs.isNaN { return .nan }
+    if lhs.isInfinite {
+      return rhs.isInfinite && lhs.sign != rhs.sign ? .nan : lhs
+    }
+    if rhs.isInfinite { return rhs }
+
+    let ldm = lhs.denominator.magnitude
+    let rdm = rhs.denominator.magnitude
+    // For full-width integers, we can make use of full-width multiplication.
+    let lcm = T.Magnitude.lcmFullWidth(ldm, rdm)
+    let a = ldm.magnitude.dividingFullWidth(lcm)
+    let b = rdm.magnitude.dividingFullWidth(lcm)
+    // FIXME: complete the rest of this algorithm, keeping in mind that it is
+    // necessary to change the sign of `a` and `b` before using them as factors.
+  }
+  */
+}
+
+extension Rational : SignedNumeric {
   @_transparent // @_inlineable
   public static prefix func - (operand: Rational) -> Rational {
     return Rational(

--- a/Sources/Rational+SignedNumeric.swift
+++ b/Sources/Rational+SignedNumeric.swift
@@ -1,0 +1,50 @@
+//
+//  Rational+SignedNumeric.swift
+//  NumericAnnex
+//
+//  Created by Xiaodi Wu on 4/15/17.
+//
+
+extension Rational /* : Numeric */ {
+  @_transparent // @_inlineable
+  public var magnitude: Rational {
+    return sign == .minus ? -self : self
+  }
+
+  // TODO: `+`, `-`
+
+  @_transparent // @_inlineable
+  public static func * (lhs: Rational, rhs: Rational) -> Rational {
+    let a = T.gcd(lhs.numerator, rhs.denominator)
+    guard a != 0 else { return .nan }
+    let b = T.gcd(rhs.numerator, lhs.denominator)
+    guard b != 0 else { return .nan }
+    return Rational(
+      numerator: (lhs.numerator / a) * (rhs.numerator / b),
+      denominator: (lhs.denominator / b) * (rhs.denominator / a)
+    )
+  }
+}
+
+extension Rational /* : SignedNumeric */ {
+  @_transparent // @_inlineable
+  public static prefix func - (operand: Rational) -> Rational {
+    return Rational(
+      numerator: -operand.numerator, denominator: operand.denominator
+    )
+  }
+
+  @_transparent // @_inlineable
+  public mutating func negate() {
+    numerator.negate()
+  }
+}
+
+extension Rational {
+  @_transparent // @_inlineable
+  public static func / (lhs: Rational, rhs: Rational) -> Rational {
+    return lhs * rhs.reciprocal()
+  }
+
+  // TODO: `%`, `rounded(_:)`
+}

--- a/Sources/Rational+SignedNumeric.swift
+++ b/Sources/Rational+SignedNumeric.swift
@@ -24,8 +24,8 @@ extension Rational : Numeric {
     let ldm = lhs.denominator.magnitude
     let rdm = rhs.denominator.magnitude
     let gcd = T.Magnitude.gcd(ldm, rdm)
-    let a = ldm / gcd
-    let b = rdm / gcd
+    let a = rdm / gcd
+    let b = ldm / gcd
 
     let n: T
     let d = T(ldm / gcd * rdm)
@@ -118,8 +118,8 @@ extension Rational where T.Magnitude : FixedWidthInteger {
     let rdm = rhs.denominator.magnitude
     // For full-width integers, we can make use of full-width multiplication.
     let lcm = T.Magnitude.lcmFullWidth(ldm, rdm)
-    let a = ldm.magnitude.dividingFullWidth(lcm)
-    let b = rdm.magnitude.dividingFullWidth(lcm)
+    let a = rdm.magnitude.dividingFullWidth(lcm)
+    let b = ldm.magnitude.dividingFullWidth(lcm)
     // TODO: Complete the rest of this algorithm.
   }
   */
@@ -152,8 +152,6 @@ extension Rational {
     // FIXME: Implement something better.
     lhs = lhs * rhs.reciprocal()
   }
-
-  // TODO: `%`
 
   /// Returns this value rounded to an integral value using the specified
   /// rounding rule.

--- a/Sources/Rational+SignedNumeric.swift
+++ b/Sources/Rational+SignedNumeric.swift
@@ -15,13 +15,29 @@ extension Rational /* : Numeric */ {
 
   @_transparent // @_inlineable
   public static func * (lhs: Rational, rhs: Rational) -> Rational {
-    let a = T.gcd(lhs.numerator, rhs.denominator)
+    let lnm = lhs.numerator.magnitude, ldm = lhs.denominator.magnitude
+    let rnm = rhs.numerator.magnitude, rdm = rhs.denominator.magnitude
+
+    // Note that if `T` is a signed fixed-width integer type, `gcd(lnm, rdm)` or
+    // `gcd(rnm, ldm)` could be equal to `-T.min`, which is not representable as
+    // a `T`. This is why the following arithmetic is performed with values of
+    // type `T.Magnitude`.
+    let a = T.Magnitude.gcd(lnm, rdm)
     guard a != 0 else { return .nan }
-    let b = T.gcd(rhs.numerator, lhs.denominator)
+    let b = T.Magnitude.gcd(rnm, ldm)
     guard b != 0 else { return .nan }
+
+    if lhs.sign == rhs.sign {
+      return Rational(
+        numerator: T(lnm / a) * T(rnm / b), denominator: T(ldm / b) * T(rdm / a)
+      )
+    }
     return Rational(
-      numerator: (lhs.numerator / a) * (rhs.numerator / b),
-      denominator: (lhs.denominator / b) * (rhs.denominator / a)
+      // Note that computing `-T(lnm / a) * T(rnm / b)` permits the numerator to
+      // be equal to `T.min` if `T` is a signed fixed-width integer type, but
+      // computing `-T((lnm / a) * (rnm / b))` does not, as `-T.min` is not
+      // representable as a `T`.
+      numerator: -T(lnm / a) * T(rnm / b), denominator: T(ldm / b) * T(rdm / a)
     )
   }
 }

--- a/Sources/Rational.swift
+++ b/Sources/Rational.swift
@@ -40,7 +40,9 @@ extension Rational {
   /// canonical form.
   @_transparent // @_inlineable
   public var isCanonical: Bool {
-    if denominator > 0 { return isIrreducible }
+    if denominator > 0 {
+      return T.Magnitude.gcd(numerator.magnitude, denominator.magnitude) == 1
+    }
     return denominator == 0 &&
       (numerator == -1 || numerator == 0 || numerator == 1)
   }
@@ -60,13 +62,6 @@ extension Rational {
   @_transparent // @_inlineable
   public var isInfinite: Bool {
     return denominator == 0 && numerator != 0
-  }
-
-  /// A Boolean value indicating whether the instance is irreducible (that is,
-  /// reduced to lowest terms).
-  @_transparent // @_inlineable
-  public var isIrreducible: Bool {
-    return T.Magnitude.gcd(numerator.magnitude, denominator.magnitude) == 1
   }
 
   /// A Boolean value indicating whether the instance is NaN ("not a number").
@@ -93,7 +88,11 @@ extension Rational {
     return denominator != 0 && numerator == 0
   }
 
-  // TODO: `magnitude`
+  /// The magnitude (absolute value) of this value.
+  @_transparent // @_inlineable
+  public var magnitude: Rational {
+    return sign == .minus ? -self : self
+  }
 
   /// The sign of this value.
   @_transparent // @_inlineable
@@ -129,8 +128,6 @@ extension Rational {
       Rational(numerator: denominator, denominator: numerator)
   }
 }
-
-// TODO: `init<U : SignedInteger>(_: Rational<U>) where U.Magnitude : UnsignedInteger` and related
 
 extension Rational : ExpressibleByIntegerLiteral {
   @_transparent // @_inlineable

--- a/Sources/Rational.swift
+++ b/Sources/Rational.swift
@@ -1,0 +1,151 @@
+//
+//  Rational.swift
+//  NumericAnnex
+//
+//  Created by Xiaodi Wu on 4/15/17.
+//
+
+/// A type to represent a rational value in canonical form.
+// @_fixed_layout
+public struct Rational<T : _SignedInteger> where T.Magnitude : _UnsignedInteger {
+  /// The numerator of the rational value.
+  public var numerator: T
+
+  /// The denominator of the rational value.
+  public var denominator: T
+
+  /// Positive infinity.
+  ///
+  /// Infinity compares greater than all finite numbers and equal to other
+  /// (positive) infinite values.
+  public static var infinity: Rational {
+    return Rational(numerator: 1, denominator: 0)
+  }
+
+  /// A quiet NaN ("not a number").
+  ///
+  /// A NaN compares not equal, not greater than, and not less than every value,
+  /// including itself. Passing a NaN to an operation generally results in NaN.
+  public static var nan: Rational {
+    return Rational(numerator: 0, denominator: 0)
+  }
+}
+
+public typealias RationalSign = FloatingPointSign
+
+extension Rational {
+  /// A Boolean value indicating whether the instance's representation is in
+  /// canonical form.
+  @_transparent // @_inlineable
+  public var isCanonical: Bool {
+    if denominator > 0 { return isIrreducible }
+    return denominator == 0 &&
+      (numerator == -1 || numerator == 0 || numerator == 1)
+  }
+
+  /// A Boolean value indicating whether the instance is finite.
+  ///
+  /// All values other than NaN and infinity are considered finite.
+  @_transparent // @_inlineable
+  public var isFinite: Bool {
+    return denominator != 0
+  }
+
+  /// A Boolean value indicating whether the instance is infinite.
+  ///
+  /// Note that `isFinite` and `isInfinite` do not form a dichotomy because NaN
+  /// is neither finite nor infinite.
+  @_transparent // @_inlineable
+  public var isInfinite: Bool {
+    return denominator == 0 && numerator != 0
+  }
+
+  /// A Boolean value indicating whether the instance is irreducible (that is,
+  /// reduced to lowest terms).
+  @_transparent // @_inlineable
+  public var isIrreducible: Bool {
+    return T.gcd(numerator, denominator) == 1
+  }
+
+  /// A Boolean value indicating whether the instance is NaN ("not a number").
+  ///
+  /// Because NaN is not equal to any value, including NaN, use this property
+  /// instead of the equal-to operator (`==`) or not-equal-to operator (`!=`) to
+  /// test whether a value is or is not NaN.
+  @_transparent // @_inlineable
+  public var isNaN: Bool {
+    return denominator == 0 && numerator == 0
+  }
+
+  /// A Boolean value indicating whether the instance is equal to zero.
+  @_transparent // @_inlineable
+  public var isZero: Bool {
+    return denominator != 0 && numerator == 0
+  }
+
+  // TODO: `magnitude`
+
+  /// The sign of this value.
+  @_transparent // @_inlineable
+  public var sign: RationalSign {
+    return (denominator < 0) == (numerator < 0) ? .plus : .minus
+  }
+
+  /// The canonicalized representation of this value.
+  @_transparent // @_inlineable
+  internal func _canonicalized() -> Rational {
+    let gcd = T.gcd(numerator, denominator)
+    guard gcd != 0 else { return self }
+    let divisor = denominator < 0 ? -gcd : gcd
+    return Rational(
+      numerator: numerator / divisor,
+      denominator: denominator / divisor
+    )
+  }
+
+  /// The reciprocal (multiplicative inverse) of this value.
+  @_transparent // @_inlineable
+  public func reciprocal() -> Rational {
+    return (numerator < 0) ?
+      Rational(numerator: -denominator, denominator: -numerator) :
+      Rational(numerator: denominator, denominator: numerator)
+  }
+}
+
+// TODO: `init<U : SignedInteger>(_: Rational<U>) where U.Magnitude : UnsignedInteger` and related
+
+extension Rational : ExpressibleByIntegerLiteral {
+  @_transparent // @_inlineable
+  public init(integerLiteral value: T) {
+    self.numerator = value
+    self.denominator = 1
+  }
+}
+
+extension Rational : CustomStringConvertible {
+  @_transparent // @_inlineable
+  public var description: String {
+    if numerator == 0 { return denominator == 0 ? "nan" : "0" }
+    if denominator == 0 { return numerator < 0 ? "-inf" : "inf" }
+    return denominator == 1 ? "\(numerator)" : "\(numerator)/\(denominator)"
+  }
+}
+
+extension Rational : Equatable {
+  @_transparent // @_inlineable
+  public static func == (lhs: Rational, rhs: Rational) -> Bool {
+    precondition(lhs.isCanonical && rhs.isCanonical)
+    if lhs.isNaN || rhs.isNaN { return false }
+    return lhs.numerator == rhs.numerator && lhs.denominator == rhs.denominator
+  }
+}
+
+// TODO: `extension Rational : Comparable`
+
+extension Rational : Hashable {
+  @_transparent // @_inlineable
+  public var hashValue: Int {
+    precondition(isCanonical)
+    return _fnv1a(numerator, denominator)
+  }
+}

--- a/Sources/Rational.swift
+++ b/Sources/Rational.swift
@@ -177,6 +177,14 @@ extension Rational : Equatable {
   }
 }
 
+extension Rational : Hashable {
+  // @_transparent // @_inlineable
+  public var hashValue: Int {
+    let t = self._canonicalized()
+    return _fnv1a(t.numerator, t.denominator)
+  }
+}
+
 extension Rational : Comparable {
   @_transparent // @_inlineable
   public static func < (lhs: Rational, rhs: Rational) -> Bool {
@@ -238,10 +246,12 @@ extension Rational where T.Magnitude : FixedWidthInteger {
   }
 }
 
-extension Rational : Hashable {
-  @_transparent // @_inlineable
-  public var hashValue: Int {
-    let t = self._canonicalized()
-    return _fnv1a(t.numerator, t.denominator)
+extension Rational : Strideable {
+  public func distance(to other: Rational) -> Rational {
+    return other - self
+  }
+  
+  public func advanced(by amount: Rational) -> Rational {
+    return self + amount
   }
 }

--- a/Sources/Rational.swift
+++ b/Sources/Rational.swift
@@ -7,7 +7,9 @@
 
 /// A type to represent a rational value in canonical form.
 // @_fixed_layout
-public struct Rational<T : _SignedInteger> where T.Magnitude : _UnsignedInteger {
+public struct Rational<
+  T : SignedInteger & _ExpressibleByBuiltinIntegerLiteral
+> where T.Magnitude : UnsignedInteger {
   /// The numerator of the rational value.
   public var numerator: T
 

--- a/Tests/NumericAnnexTests/NumericAnnexTests.swift
+++ b/Tests/NumericAnnexTests/NumericAnnexTests.swift
@@ -719,6 +719,56 @@ class NumericAnnexTests: XCTestCase {
     XCTAssertEqual(b * a, 5 / 2 as Ratio)
     XCTAssertEqual(a / b, 9 / 10 as Ratio)
     XCTAssertEqual(b / a, 10 / 9 as Ratio)
+
+    XCTAssertEqual((10 / 9 as Ratio).mixed.whole, 1)
+    XCTAssertEqual((10 / 9 as Ratio).mixed.fractional, 1 / 9)
+
+    // Test special values.
+    let pn = Ratio.nan
+    let pi = Ratio.infinity
+    let ni = -Ratio.infinity
+
+    XCTAssertTrue((pn + pn).isNaN)
+    XCTAssertTrue((pn - pn).isNaN)
+    XCTAssertTrue((pn * pn).isNaN)
+    XCTAssertTrue((pn / pn).isNaN)
+
+    XCTAssertEqual(pi + pi, .infinity)
+    XCTAssertEqual(ni + ni, -.infinity)
+    XCTAssertEqual(pi + 0, .infinity)
+    XCTAssertEqual(ni + 0, -.infinity)
+    XCTAssertEqual(pi + 42, .infinity)
+    XCTAssertEqual(pi - 42, .infinity)
+    XCTAssertEqual(ni + 42, -.infinity)
+    XCTAssertEqual(ni - 42, -.infinity)
+
+    XCTAssertTrue((pi + ni).isNaN)
+    XCTAssertTrue((ni + pi).isNaN)
+    XCTAssertTrue((pi - pi).isNaN)
+    XCTAssertTrue((-pi + pi).isNaN)
+
+    XCTAssertTrue((0 / 0 as Ratio).isNaN)
+    XCTAssert((0 / 0 as Ratio) != .nan) // NaN compares unequal to everything.
+    XCTAssertTrue((42 / 0 as Ratio).isInfinite)
+    XCTAssertTrue((-42 / 0 as Ratio).isInfinite)
+    XCTAssert(42 / 0 as Ratio == .infinity)
+    XCTAssert(-42 / 0 as Ratio == -.infinity)
+    XCTAssertEqual((42 / 0 as Ratio).description, "inf")
+    XCTAssertEqual((-42 / 0 as Ratio).description, "-inf")
+
+    XCTAssertEqual(pi * pi, .infinity)
+    XCTAssertEqual(pi * ni, -.infinity)
+    XCTAssertEqual(ni * pi, -.infinity)
+    XCTAssertEqual(ni * ni, .infinity)
+
+    XCTAssertTrue((pi * 0).isNaN)
+    XCTAssertTrue((ni * 0).isNaN)
+    XCTAssertTrue((0 * pi).isNaN)
+    XCTAssertTrue((0 * ni).isNaN)
+    XCTAssertTrue((pn * pi).isNaN)
+    XCTAssertTrue((pi * pn).isNaN)
+    XCTAssertTrue((pn * ni).isNaN)
+    XCTAssertTrue((ni * pn).isNaN)
   }
 
   static var allTests = [

--- a/Tests/NumericAnnexTests/NumericAnnexTests.swift
+++ b/Tests/NumericAnnexTests/NumericAnnexTests.swift
@@ -709,12 +709,16 @@ class NumericAnnexTests: XCTestCase {
 
     let b = 5 / 3 as Rational<Int>
     XCTAssertEqual(b.description, "5/3")
+    XCTAssertLessThan(a, b)
 
-    let product = a * b
-    XCTAssertEqual(product, 5 / 2 as Rational<Int>)
-    
-    let quotient = a / b
-    XCTAssertEqual(quotient, 9 / 10 as Rational<Int>)
+    XCTAssertEqual(a + b, 19 / 6 as Ratio)
+    XCTAssertEqual(b + a, 19 / 6 as Ratio)
+    XCTAssertEqual(a - b, -1 / 6 as Ratio)
+    XCTAssertEqual(b - a, 1 / 6 as Ratio)
+    XCTAssertEqual(a * b, 5 / 2 as Ratio)
+    XCTAssertEqual(b * a, 5 / 2 as Ratio)
+    XCTAssertEqual(a / b, 9 / 10 as Ratio)
+    XCTAssertEqual(b / a, 10 / 9 as Ratio)
   }
 
   static var allTests = [

--- a/Tests/NumericAnnexTests/NumericAnnexTests.swift
+++ b/Tests/NumericAnnexTests/NumericAnnexTests.swift
@@ -696,6 +696,21 @@ class NumericAnnexTests: XCTestCase {
     XCTAssertTrue(result.imaginary.isNaN)
   }
 
+  func testRational() {
+    let a = 6 / 4 as Rational<Int>
+    XCTAssertEqual(a.description, "3/2")
+    XCTAssertEqual(a, 3 / 2 as Rational<Int>)
+
+    let b = 5 / 3 as Rational<Int>
+    XCTAssertEqual(b.description, "5/3")
+
+    let product = a * b
+    XCTAssertEqual(product, 5 / 2 as Rational<Int>)
+    
+    let quotient = a / b
+    XCTAssertEqual(quotient, 9 / 10 as Rational<Int>)
+  }
+
   static var allTests = [
     ("testComplexAddition", testComplexAddition),
     ("testComplexDivision", testComplexDivision),
@@ -705,5 +720,6 @@ class NumericAnnexTests: XCTestCase {
     ("testComplexExponentiation", testComplexExponentiation),
     ("testComplexTrigonometry", testComplexTrigonometry),
     ("testComplexHyperbolicFunctions", testComplexHyperbolicFunctions),
+    ("testRational", testRational),
   ]
 }

--- a/Tests/NumericAnnexTests/NumericAnnexTests.swift
+++ b/Tests/NumericAnnexTests/NumericAnnexTests.swift
@@ -41,6 +41,12 @@ class NumericAnnexTests: XCTestCase {
 
   let pnpn = Complex(real: Double.nan, imaginary: .nan)
 
+  func testComplexInitialization() {
+    let foo = Complex128(42 as Double)
+    let bar = 42 as Complex128
+    XCTAssertEqual(foo, bar)
+  }
+
   func testComplexAddition() {
     let foo: Complex128 = 1.0 + 2.0 * .i
     let bar: Complex128 = 2 + 4 * .i
@@ -712,6 +718,7 @@ class NumericAnnexTests: XCTestCase {
   }
 
   static var allTests = [
+    ("testComplexInitialization", testComplexInitialization),
     ("testComplexAddition", testComplexAddition),
     ("testComplexDivision", testComplexDivision),
     ("testComplexLogarithm", testComplexLogarithm),


### PR DESCRIPTION
Work in progress to add a `Rational` type.

### Detailed design

* To create a new `Rational` instance, the intended spelling for general use is `let i: Rational<Int> = 3 / 4`, which will always reduce the numerator and denominator to lowest terms. However, it is possible to construct a `Rational` instance with an unreduced numerator and denominator through `Rational.init(numerator:denominator:)`.

* Arithmetic operations with canonical (i.e., reduced) fractions are guaranteed to return canonical fractions; arithmetic operations with unreduced fractions are guaranteed to return correct answers equal to--but not necessarily in--their canonical form.

* Comparison never overflows. Multiplication will overflow only if the final result is not representable as a value of type `Rational<T>`. However, at present, addition may overflow __even if the final result is representable as a value of type `Rational<T>`__ if intermediate computational steps require numerators or denominators not representable as values of type `T`.

* For simplicity, `Rational` is limited to numerators and denominators which are of a type that conform to `SignedInteger`. Therefore, `Rational<T>.Magnitude` must be `Rational<T>` and not `Rational<T.Magnitude>`. The implication is that we must prohibit `T.min / 1` from being a value of type `Rational<T>`, since its magnitude is not representable as a `Rational<T>.Magnitude`.

> Even without the `Rational.Magnitude` requirement, representing `1 / T.min` would be problematic: the sign is stored in the numerator when the fraction is canonicalized, but `-1 / -T.min` cannot be represented as a `Rational<T>`.


### Outstanding issues

An optimal implementation of `Rational.+` would make use of full-width multiplication and division, which is not yet implemented in the standard library.
