### PR TITLE
Expand testing

### DIFF
--- a/Sources/Complex.swift
+++ b/Sources/Complex.swift
@@ -495,9 +495,9 @@ extension Complex : Numeric {
 
   @_transparent // @_inlineable
   public static func + (lhs: Complex, rhs: Complex) -> Complex {
-    return Complex(
-      real: lhs.real + rhs.real, imaginary: lhs.imaginary + rhs.imaginary
-    )
+    var lhs = lhs
+    lhs += rhs
+    return lhs
   }
 
   @_transparent // @_inlineable
@@ -508,9 +508,9 @@ extension Complex : Numeric {
 
   @_transparent // @_inlineable
   public static func - (lhs: Complex, rhs: Complex) -> Complex {
-    return Complex(
-      real: lhs.real - rhs.real, imaginary: lhs.imaginary - rhs.imaginary
-    )
+    var lhs = lhs
+    lhs -= rhs
+    return lhs
   }
 
   @_transparent // @_inlineable
@@ -529,9 +529,7 @@ extension Complex : Numeric {
 
   @_transparent // @_inlineable
   public static func *= (lhs: inout Complex, rhs: Complex) {
-    let t = lhs.real
-    lhs.real = lhs.real * rhs.real - lhs.imaginary * rhs.imaginary
-    lhs.imaginary = t * rhs.imaginary + lhs.imaginary * rhs.real
+    lhs = lhs * rhs
   }
 }
 
@@ -589,7 +587,6 @@ extension Complex : Math {
       real: (lhs.real * ratio + lhs.imaginary) / denominator,
       imaginary: (lhs.imaginary * ratio - lhs.real) / denominator
     )
-
     /*
     let denominator = rhs.squaredMagnitude
     return Complex(
@@ -603,19 +600,7 @@ extension Complex : Math {
 
   @_transparent // @_inlineable
   public static func /= (lhs: inout Complex, rhs: Complex) {
-    // Prevent avoidable overflow; see Numerical Recipes.
-    let t = lhs.real
-    if rhs.real.magnitude >= rhs.imaginary.magnitude {
-      let ratio = rhs.imaginary / rhs.real
-      let denominator = rhs.real + rhs.imaginary * ratio
-      lhs.real = (lhs.real + lhs.imaginary * ratio) / denominator
-      lhs.imaginary = (lhs.imaginary - t * ratio) / denominator
-    } else {
-      let ratio = rhs.real / rhs.imaginary
-      let denominator = rhs.real * ratio + rhs.imaginary
-      lhs.real = (lhs.real * ratio + lhs.imaginary) / denominator
-      lhs.imaginary = (lhs.imaginary * ratio - t) / denominator
-    }
+    lhs = lhs / rhs
   }
 
   // @_transparent // @_inlineable

--- a/Sources/Math.swift
+++ b/Sources/Math.swift
@@ -198,17 +198,15 @@ public protocol Math : SignedNumeric {
 }
 
 extension Math {
-  // @_transparent
   /// The mathematical constant _e_, or Euler's number (default implementation).
   public static var e: Self {
     return Self.exp(1 as Self)
   }
 
-  // @_transparent
   /// The mathematical constant phi (_φ_), or golden ratio (default
   /// implementation).
   public static var phi: Self {
-    return Self.sqrt(((1 as Self) + Self.sqrt(5 as Self)) / (2 as Self))
+    return ((1 as Self) + Self.sqrt(5 as Self)) / (2 as Self)
   }
 
   public func binaryExponential() -> Self {
@@ -233,10 +231,6 @@ extension Math {
 
   public func naturalLogarithmOnePlus() -> Self {
     return Self.log(self + (1 as Self))
-  }
-
-  public func cubeRoot() -> Self {
-    return Self.pow(self, 1 / 3 as Self)
   }
 
   public func tangent() -> Self {

--- a/Sources/Real.swift
+++ b/Sources/Real.swift
@@ -73,11 +73,16 @@ public protocol Real : Math, FloatingPoint {
 extension Real {
   public static func hypot(_ x: Self, _ y: Self) -> Self {
     var x = abs(x), y = abs(y)
-    if x < y {
-      swap(&x, &y)
-    }
+    if x.isInfinite { return x }
+    if y.isInfinite { return y }
+    if x == 0 { return y }
+    if x < y { swap(&x, &y) }
     let ratio = y / x
     return x * .sqrt(1 + ratio * ratio)
+  }
+
+  public func cubeRoot() -> Self {
+    return sign == .minus ? -.exp(.log(-self) / 3) : .exp(.log(self) / 3)
   }
 
   public func inverseTangent(dividingBy other: Self) -> Self {

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -2,6 +2,7 @@ import XCTest
 @testable import NumericAnnexTests
 
 XCTMain([
+  testCase(ExponentiationTests.allTests),
   testCase(FactoringTests.allTests),
   testCase(RealTests.allTests),
   testCase(RationalTests.allTests),

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -2,6 +2,7 @@ import XCTest
 @testable import NumericAnnexTests
 
 XCTMain([
+  testCase(RealTests.allTests),
   testCase(FactoringTests.allTests),
   testCase(RationalTests.allTests),
   testCase(ComplexTests.allTests),

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -2,8 +2,8 @@ import XCTest
 @testable import NumericAnnexTests
 
 XCTMain([
-  testCase(RealTests.allTests),
   testCase(FactoringTests.allTests),
+  testCase(RealTests.allTests),
   testCase(RationalTests.allTests),
   testCase(ComplexTests.allTests),
   testCase(RandomXorshiftTests.allTests),

--- a/Tests/NumericAnnexTests/ComplexTests.swift
+++ b/Tests/NumericAnnexTests/ComplexTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 @testable import NumericAnnex
 
-class ComplexTests: XCTestCase {
+class ComplexTests : XCTestCase {
   let pzpz = Complex(real: +0.0, imaginary: +0.0)
   let pznz = Complex(real: +0.0, imaginary: -0.0)
   let nzpz = Complex(real: -0.0, imaginary: +0.0)

--- a/Tests/NumericAnnexTests/ExponentiationTests.swift
+++ b/Tests/NumericAnnexTests/ExponentiationTests.swift
@@ -1,0 +1,35 @@
+import XCTest
+@testable import NumericAnnex
+
+class ExponentiationTests : XCTestCase {
+  func testIntPow() {
+    for i in -21...21 {
+      for j in -7...7 {
+        if i == 0 && j < 0 {
+          // In this case, Int.pow(i, j) causes a division-by-zero error.
+          // Likewise, Double.pow(Double(i), Double(j)) also causes the same
+          // error.
+          continue
+        }
+        let actual = Int.pow(i, j)
+        let expected = Int(Double.pow(Double(i), Double(j)))
+        XCTAssertEqual(actual, expected)
+      }
+    }
+  }
+
+  func testUIntPow() {
+    for i in (0 as UInt)...21 {
+      for j in (0 as UInt)...7 {
+        let actual = UInt.pow(i, j)
+        let expected = UInt(Double.pow(Double(i), Double(j)))
+        XCTAssertEqual(actual, expected)
+      }
+    }
+  }
+
+  static var allTests = [
+    ("testIntPow", testIntPow),
+    ("testUIntPow", testUIntPow),
+  ]
+}

--- a/Tests/NumericAnnexTests/FactoringTests.swift
+++ b/Tests/NumericAnnexTests/FactoringTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 @testable import NumericAnnex
 
-class FactoringTests: XCTestCase {
+class FactoringTests : XCTestCase {
   func testGCD() {
     XCTAssertEqual(UInt.gcd(18, 84), 6)
     XCTAssertEqual(UInt.gcd(24, 60), 12)

--- a/Tests/NumericAnnexTests/RandomXoroshiroTests.swift
+++ b/Tests/NumericAnnexTests/RandomXoroshiroTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 @testable import NumericAnnex
 
-class RandomXoroshiroTests: XCTestCase {
+class RandomXoroshiroTests : XCTestCase {
   func test_1_2() {
     let rng = Random.Xoroshiro(state: (1, 2))
     // Values were generated using the reference implementation found at:

--- a/Tests/NumericAnnexTests/RandomXorshiftTests.swift
+++ b/Tests/NumericAnnexTests/RandomXorshiftTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 @testable import NumericAnnex
 
-class RandomXorshiftTests: XCTestCase {
+class RandomXorshiftTests : XCTestCase {
   func test_1_2() {
     let rng = Random(state: (1, 2))
     // Values were generated using the reference implementation found at:

--- a/Tests/NumericAnnexTests/RationalTests.swift
+++ b/Tests/NumericAnnexTests/RationalTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 @testable import NumericAnnex
 
-class RationalTests: XCTestCase {
+class RationalTests : XCTestCase {
   func testRational() {
     let a = 6 / 4 as Rational<Int>
     XCTAssertEqual(a.description, "3/2")

--- a/Tests/NumericAnnexTests/RealTests.swift
+++ b/Tests/NumericAnnexTests/RealTests.swift
@@ -1,0 +1,507 @@
+import XCTest
+@testable import NumericAnnex
+
+/// A type that wraps `Double` and implements the methods required for
+/// conformance to `Real`.
+struct MockReal {
+  var _value: Double
+
+  init(_ value: Double) {
+    self._value = value
+  }
+}
+
+extension MockReal : ExpressibleByIntegerLiteral {
+  init(integerLiteral value: Double.IntegerLiteralType) {
+    self = MockReal(Double(integerLiteral: value))
+  }
+}
+
+extension MockReal : Hashable {
+  var hashValue: Int {
+    return _value.hashValue
+  }
+}
+
+extension MockReal : Strideable, _Strideable {
+  func distance(to other: MockReal) -> MockReal {
+    return MockReal(_value.distance(to: other._value))
+  }
+
+  func advanced(by n: MockReal) -> MockReal {
+    return MockReal(_value.advanced(by: n._value))
+  }
+}
+
+extension MockReal : Numeric {
+  var magnitude: MockReal {
+    return MockReal(_value.magnitude)
+  }
+
+  init?<T>(exactly source: T) where T : BinaryInteger {
+    guard let d = Double(exactly: source) else { return nil }
+    self = MockReal(d)
+  }
+
+  static func + (lhs: MockReal, rhs: MockReal) -> MockReal {
+    return MockReal(lhs._value + rhs._value)
+  }
+
+  static func += (lhs: inout MockReal, rhs: MockReal) {
+    lhs._value += rhs._value
+  }
+
+  static func - (lhs: MockReal, rhs: MockReal) -> MockReal {
+    return MockReal(lhs._value - rhs._value)
+  }
+
+  static func -= (lhs: inout MockReal, rhs: MockReal) {
+    lhs._value -= rhs._value
+  }
+
+  static func * (lhs: MockReal, rhs: MockReal) -> MockReal {
+    return MockReal(lhs._value * rhs._value)
+  }
+
+  static func *= (lhs: inout MockReal, rhs: MockReal) {
+    lhs._value *= rhs._value
+  }
+}
+
+extension MockReal : FloatingPoint {
+  init(_ value: Int) {
+    self = MockReal(Double(value))
+  }
+
+  init(_ value: Int8) {
+    self = MockReal(Double(value))
+  }
+
+  init(_ value: Int16) {
+    self = MockReal(Double(value))
+  }
+  
+  init(_ value: Int32) {
+    self = MockReal(Double(value))
+  }
+
+  init(_ value: Int64) {
+    self = MockReal(Double(value))
+  }
+
+  init(_ value: UInt) {
+    self = MockReal(Double(value))
+  }
+
+  init(_ value: UInt8) {
+    self = MockReal(Double(value))
+  }
+
+  init(_ value: UInt16) {
+    self = MockReal(Double(value))
+  }
+
+  init(_ value: UInt32) {
+    self = MockReal(Double(value))
+  }
+
+  init(_ value: UInt64) {
+    self = MockReal(Double(value))
+  }
+
+  init(sign: FloatingPointSign, exponent: Int, significand: MockReal) {
+    self = MockReal(
+      Double(sign: sign, exponent: exponent, significand: significand._value)
+    )
+  }
+
+  init(signOf s: MockReal, magnitudeOf m: MockReal) {
+    self = MockReal(Double(signOf: s._value, magnitudeOf: m._value))
+  }
+
+  static var greatestFiniteMagnitude = MockReal(.greatestFiniteMagnitude)
+
+  static var infinity = MockReal(.infinity)
+
+  static var leastNonzeroMagnitude = MockReal(.leastNonzeroMagnitude)
+
+  static var leastNormalMagnitude = MockReal(.leastNormalMagnitude)
+
+  static var nan = MockReal(.nan)
+
+  static var pi = MockReal(.pi)
+
+  static var radix = Double.radix
+
+  static var signalingNaN = MockReal(.signalingNaN)
+
+  static func / (lhs: MockReal, rhs: MockReal) -> MockReal {
+    return MockReal(lhs._value / rhs._value)
+  }
+
+  static func /= (lhs: inout MockReal, rhs: MockReal) {
+    lhs._value /= rhs._value
+  }
+
+  static prefix func - (x: MockReal) -> MockReal {
+    return MockReal(-x._value)
+  }
+
+  var exponent: Int {
+    return _value.exponent
+  }
+
+  var isCanonical: Bool {
+    return _value.isCanonical
+  }
+
+  var isFinite: Bool {
+    return _value.isFinite
+  }
+
+  var isInfinite: Bool {
+    return _value.isInfinite
+  }
+
+  var isNaN: Bool {
+    return _value.isNaN
+  }
+
+  var isNormal: Bool {
+    return _value.isNormal
+  }
+
+  var isSignalingNaN: Bool {
+    return _value.isSignalingNaN
+  }
+
+  var isSubnormal: Bool {
+    return _value.isSubnormal
+  }
+
+  var isZero: Bool {
+    return _value.isZero
+  }
+
+  var nextUp: MockReal {
+    return MockReal(_value.nextUp)
+  }
+
+  var sign: FloatingPointSign {
+    return _value.sign
+  }
+
+  var significand: MockReal {
+    return MockReal(_value.significand)
+  }
+
+  var ulp: MockReal {
+    return MockReal(_value.ulp)
+  }
+
+  mutating func addProduct(_ lhs: MockReal, _ rhs: MockReal) {
+    _value.addProduct(lhs._value, rhs._value)
+  }
+
+  mutating func formRemainder(dividingBy other: MockReal) {
+    _value.formRemainder(dividingBy: other._value)
+  }
+
+  mutating func formSquareRoot() {
+    _value.formSquareRoot()
+  }
+
+  mutating func formTruncatingRemainder(dividingBy other: MockReal) {
+    _value.formTruncatingRemainder(dividingBy: other._value)
+  }
+
+  func isEqual(to other: MockReal) -> Bool {
+    return _value.isEqual(to: other._value)
+  }
+
+  func isLess(than other: MockReal) -> Bool {
+    return _value.isLess(than: other._value)
+  }
+
+  func isLessThanOrEqualTo(_ other: MockReal) -> Bool {
+    return _value.isLessThanOrEqualTo(other._value)
+  }
+
+  func isTotallyOrdered(belowOrEqualTo other: MockReal) -> Bool {
+    return _value.isTotallyOrdered(belowOrEqualTo: other._value)
+  }
+
+  mutating func negate() {
+    _value.negate()
+  }
+
+  mutating func round(_ rule: FloatingPointRoundingRule) {
+    _value.round(rule)
+  }
+}
+
+extension MockReal : Real {
+  func naturalExponential() -> MockReal {
+    return MockReal(_value.naturalExponential())
+  }
+
+  func naturalLogarithm() -> MockReal {
+    return MockReal(_value.naturalLogarithm())
+  }
+
+  func power(of base: MockReal) -> MockReal {
+    return MockReal(_value.power(of: base._value))
+  }
+
+  func sine() -> MockReal {
+    return MockReal(_value.sine())
+  }
+
+  func cosine() -> MockReal {
+    return MockReal(_value.cosine())
+  }
+
+  func inverseSine() -> MockReal {
+    return MockReal(_value.inverseSine())
+  }
+
+  func inverseCosine() -> MockReal {
+    return MockReal(_value.inverseCosine())
+  }
+
+  func inverseTangent() -> MockReal {
+    return MockReal(_value.inverseTangent())
+  }
+
+  func hyperbolicSine() -> MockReal {
+    return MockReal(_value.hyperbolicSine())
+  }
+
+  func hyperbolicCosine() -> MockReal {
+    return MockReal(_value.hyperbolicCosine())
+  }
+
+  func inverseHyperbolicSine() -> MockReal {
+    return MockReal(_value.inverseHyperbolicSine())
+  }
+
+  func inverseHyperbolicCosine() -> MockReal {
+    return MockReal(_value.inverseHyperbolicCosine())
+  }
+
+  func inverseHyperbolicTangent() -> MockReal {
+    return MockReal(_value.inverseHyperbolicTangent())
+  }
+
+  func error() -> MockReal {
+    return MockReal(_value.error())
+  }
+
+  func complementaryError() -> MockReal {
+    return MockReal(_value.complementaryError())
+  }
+
+  func gamma() -> MockReal {
+    return MockReal(_value.gamma())
+  }
+
+  func logarithmicGamma() -> MockReal {
+    return MockReal(_value.logarithmicGamma())
+  }
+}
+
+class RealTests: XCTestCase {
+  func testTranscendentalConstants() {
+    XCTAssertEqual(Double.pi, MockReal.pi._value)
+    XCTAssertEqualWithAccuracy(
+      Double.e, MockReal.e._value,
+      accuracy: abs(Double.e * 0.000_000_000_001)
+    )
+    XCTAssertEqualWithAccuracy(
+      Double.phi, MockReal.phi._value,
+      accuracy: abs(Double.phi * 0.000_000_000_001)
+    )
+  }
+
+  func testExp2() {
+    for i in -42...42 {
+      let d = Double(i)
+      let m = MockReal(d)
+      XCTAssertEqualWithAccuracy(
+        Double.exp2(d), MockReal.exp2(m)._value,
+        accuracy: abs(Double.exp2(d) * 0.000_000_000_001)
+      )
+    }
+  }
+
+  func testExp10() {
+    for i in -42...42 {
+      let d = Double(i)
+      let m = MockReal(d)
+      XCTAssertEqualWithAccuracy(
+        Double.exp10(d), MockReal.exp10(m)._value,
+        accuracy: abs(Double.exp10(d) * 0.000_000_000_001)
+      )
+    }
+  }
+
+  func testExpm1() {
+    for i in -42...42 {
+      let d = Double(i)
+      let m = MockReal(d)
+      XCTAssertEqualWithAccuracy(
+        Double.expm1(d), MockReal.expm1(m)._value,
+        accuracy: abs(Double.expm1(d) * 0.000_000_000_001)
+      )
+    }
+  }
+
+  func testLog2() {
+    for i in 1...85 {
+      let d = Double(i)
+      let m = MockReal(d)
+      XCTAssertEqualWithAccuracy(
+        Double.log2(d), MockReal.log2(m)._value,
+        accuracy: abs(Double.log2(d) * 0.000_000_000_001)
+      )
+    }
+  }
+
+  func testLog10() {
+    for i in 1...85 {
+      let d = Double(i)
+      let m = MockReal(d)
+      XCTAssertEqualWithAccuracy(
+        Double.log10(d), MockReal.log10(m)._value,
+        accuracy: abs(Double.log10(d) * 0.000_000_000_001)
+      )
+    }
+  }
+
+  func testLog1p() {
+    for i in 1...85 {
+      let d = Double(i)
+      let m = MockReal(d)
+      XCTAssertEqualWithAccuracy(
+        Double.log1p(d), MockReal.log1p(m)._value,
+        accuracy: abs(Double.log1p(d) * 0.000_000_000_001)
+      )
+    }
+  }
+
+  func testCbrt() {
+    for i in -42...42 {
+      let d = Double(i)
+      let m = MockReal(d)
+      XCTAssertEqualWithAccuracy(
+        Double.cbrt(d), MockReal.cbrt(m)._value,
+        accuracy: abs(Double.cbrt(d) * 0.000_000_000_001)
+      )
+    }
+  }
+
+  func testTan() {
+    for i in -42...42 {
+      let d = Double(i)
+      let m = MockReal(d)
+      XCTAssertEqualWithAccuracy(
+        Double.tan(d), MockReal.tan(m)._value,
+        accuracy: abs(Double.tan(d) * 0.000_000_000_001)
+      )
+    }
+  }
+
+  func testTanh() {
+    for i in -42...42 {
+      let d = Double(i)
+      let m = MockReal(d)
+      XCTAssertEqualWithAccuracy(
+        Double.tanh(d), MockReal.tanh(m)._value,
+        accuracy: abs(Double.tanh(d) * 0.000_000_000_001)
+      )
+    }
+  }
+
+  func testHypot() {
+    for i in -42...42 {
+      let dx = Double(i)
+      let mx = MockReal(dx)
+      for j in -42...42 {
+        let dy = Double(j)
+        let my = MockReal(dy)
+        XCTAssertEqualWithAccuracy(
+          Double.hypot(dx, dy),
+          MockReal.hypot(mx, my)._value,
+          accuracy: abs(Double.hypot(dx, dy) * 0.000_000_000_001)
+        )
+      }
+    }
+    // Test special values.
+    XCTAssertEqual(MockReal.hypot(.infinity, .nan), .infinity)
+    XCTAssertEqual(MockReal.hypot(.infinity, .infinity), .infinity)
+    XCTAssertEqual(MockReal.hypot(.infinity, 42), .infinity)
+    XCTAssertEqual(MockReal.hypot(42, -.infinity), .infinity)
+    XCTAssertEqual(MockReal.hypot(-.infinity, -.infinity), .infinity)
+    XCTAssertEqual(MockReal.hypot(.nan, -.infinity), .infinity)
+    XCTAssertTrue(MockReal.hypot(.nan, .nan).isNaN)
+    XCTAssertTrue(MockReal.hypot(.nan, 42).isNaN)
+    XCTAssertTrue(MockReal.hypot(42, .nan).isNaN)
+  }
+
+  func testAtan2() {
+    for i in -42...42 {
+      let dx = Double(i)
+      let mx = MockReal(dx)
+      for j in -42...42 {
+        let dy = Double(j)
+        let my = MockReal(dy)
+        XCTAssertEqualWithAccuracy(
+          Double.atan2(dy, dx),
+          MockReal.atan2(my, mx)._value,
+          accuracy: abs(Double.atan2(dy, dx) * 0.000_000_000_001)
+        )
+      }
+    }
+    // Test special values.
+    XCTAssertEqual(MockReal.atan2(0, -42), .pi)
+    XCTAssertEqual(MockReal.atan2(MockReal(-0.0), -42), -.pi)
+    XCTAssertTrue(MockReal.atan2(0, 42).isZero)
+    XCTAssertTrue(MockReal.atan2(0, 42).sign == .plus)
+    XCTAssertTrue(MockReal.atan2(MockReal(-0.0), 42).isZero)
+    XCTAssertTrue(MockReal.atan2(MockReal(-0.0), 42).sign == .minus)
+    XCTAssertEqual(MockReal.atan2(.infinity, 42), .pi / 2)
+    XCTAssertEqual(MockReal.atan2(-.infinity, 42), -.pi / 2)
+    XCTAssertEqual(MockReal.atan2(.infinity, -.infinity), 3 * .pi / 4)
+    XCTAssertEqual(MockReal.atan2(-.infinity, -.infinity), -3 * .pi / 4)
+    XCTAssertEqual(MockReal.atan2(.infinity, .infinity), .pi / 4)
+    XCTAssertEqual(MockReal.atan2(-.infinity, .infinity), -.pi / 4)
+    XCTAssertEqual(MockReal.atan2(-42, 0), -.pi / 2)
+    XCTAssertEqual(MockReal.atan2(-42, MockReal(-0.0)), -.pi / 2)
+    XCTAssertEqual(MockReal.atan2(42, 0), .pi / 2)
+    XCTAssertEqual(MockReal.atan2(42, MockReal(-0.0)), .pi / 2)
+    XCTAssertEqual(MockReal.atan2(42, -.infinity), .pi)
+    XCTAssertEqual(MockReal.atan2(-42, -.infinity), -.pi)
+    XCTAssertTrue(MockReal.atan2(42, .infinity).isZero)
+    XCTAssertTrue(MockReal.atan2(42, .infinity).sign == .plus)
+    XCTAssertTrue(MockReal.atan2(-42, .infinity).isZero)
+    XCTAssertTrue(MockReal.atan2(-42, .infinity).sign == .minus)
+    XCTAssertTrue(MockReal.atan2(.nan, .nan).isNaN)
+    XCTAssertTrue(MockReal.atan2(.nan, 42).isNaN)
+    XCTAssertTrue(MockReal.atan2(42, .nan).isNaN)
+  }
+
+  static var allTests = [
+    ("testTranscendentalConstants", testTranscendentalConstants),
+    ("testExp2", testExp2),
+    ("testExp10", testExp10),
+    ("testExpm1", testExpm1),
+    ("testLog2", testLog2),
+    ("testLog10", testLog10),
+    ("testLog1p", testLog1p),
+    ("testCbrt", testCbrt),
+    ("testTan", testTan),
+    ("testTanh", testTanh),
+    ("testHypot", testHypot),
+    ("testAtan2", testAtan2),
+  ]
+}


### PR DESCRIPTION
This PR adds tests for `BinaryInteger.pow` and for default implementations in `Math` and `Real`. In addition:

* The default implementation of `cubeRoot` is corrected and removed from `Math` to `Real`.
* A correction is made for an error in the default implementation of `Math.phi`.
* Special values are now handled in the default implementation of `Real.hypot`.

This PR also includes an incidental simplification of some operator implementations in `Complex`, which will simplify later testing.