### PR TITLE
Update .travis.yml to enable multiplatform CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,4 @@ matrix:
       language: objective-c
       osx_image: xcode9
       script:
-        - swift package generate-xcodeproj && xcodebuild clean test -project NumericAnnex.xcodeproj -scheme NumericAnnex
+        - swift package generate-xcodeproj && xcodebuild clean test -project NumericAnnex.xcodeproj -scheme NumericAnnex-Package

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,18 @@
-language: generic
-sudo: required
-dist: trusty
-before_install:
-  - wget -q -O - https://swift.org/keys/all-keys.asc | gpg --import -
-  - wget https://swift.org/builds/swift-4.0-branch/ubuntu1404/swift-4.0-DEVELOPMENT-SNAPSHOT-2017-06-12-a/swift-4.0-DEVELOPMENT-SNAPSHOT-2017-06-12-a-ubuntu14.04.tar.gz
-  - tar xzf swift-4.0-DEVELOPMENT-SNAPSHOT-2017-06-12-a-ubuntu14.04.tar.gz
-  - export PATH=${PWD}/swift-4.0-DEVELOPMENT-SNAPSHOT-2017-06-12-a-ubuntu14.04/usr/bin:"${PATH}"
-script:
-  - swift test -Xcc -D_GNU_SOURCE=1
+matrix:
+  include:
+    - os: linux
+      language: generic
+      sudo: required
+      dist: trusty
+      before_install:
+        - wget -q -O - https://swift.org/keys/all-keys.asc | gpg --import -
+        - wget https://swift.org/builds/swift-4.0-branch/ubuntu1404/swift-4.0-DEVELOPMENT-SNAPSHOT-2017-06-12-a/swift-4.0-DEVELOPMENT-SNAPSHOT-2017-06-12-a-ubuntu14.04.tar.gz
+        - tar xzf swift-4.0-DEVELOPMENT-SNAPSHOT-2017-06-12-a-ubuntu14.04.tar.gz
+        - export PATH=${PWD}/swift-4.0-DEVELOPMENT-SNAPSHOT-2017-06-12-a-ubuntu14.04/usr/bin:"${PATH}"
+      script:
+        - swift test -Xcc -D_GNU_SOURCE=1
+    - os: osx
+      language: objective-c
+      osx_image: xcode9
+      script:
+        - swift package generate-xcodeproj && xcodebuild clean test -project NumericAnnex.xcodeproj -scheme NumericAnnex


### PR DESCRIPTION
This PR modifies the Travis CI configuration file to set up testing on macOS (in addition to Linux).

The macOS job uses `xcodebuild` to test the Xcode project generated by the Swift Package Manager.
