### PR TITLE
Update generic algorithms for revised integer protocols [NFC]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ matrix:
       dist: trusty
       before_install:
         - wget -q -O - https://swift.org/keys/all-keys.asc | gpg --import -
-        - wget https://swift.org/builds/swift-4.0-branch/ubuntu1404/swift-4.0-DEVELOPMENT-SNAPSHOT-2017-07-13-a/swift-4.0-DEVELOPMENT-SNAPSHOT-2017-07-13-a-ubuntu14.04.tar.gz
-        - tar xzf swift-4.0-DEVELOPMENT-SNAPSHOT-2017-07-13-a-ubuntu14.04.tar.gz
-        - export PATH=${PWD}/swift-4.0-DEVELOPMENT-SNAPSHOT-2017-07-13-a-ubuntu14.04/usr/bin:"${PATH}"
+        - wget https://swift.org/builds/swift-4.0-branch/ubuntu1404/swift-4.0-DEVELOPMENT-SNAPSHOT-2017-08-04-a/swift-4.0-DEVELOPMENT-SNAPSHOT-2017-08-04-a-ubuntu14.04.tar.gz
+        - tar xzf swift-4.0-DEVELOPMENT-SNAPSHOT-2017-08-04-a-ubuntu14.04.tar.gz
+        - export PATH=${PWD}/swift-4.0-DEVELOPMENT-SNAPSHOT-2017-08-04-a-ubuntu14.04/usr/bin:"${PATH}"
       script:
         - swift test -Xcc -D_GNU_SOURCE=1
     - os: osx

--- a/Sources/Math.swift
+++ b/Sources/Math.swift
@@ -5,11 +5,10 @@
 //  Created by Xiaodi Wu on 3/31/17.
 //
 
-/// A signed numeric type that provides square root, cube root, and elementary
-/// transcendental functions.
+/// A signed numeric type that supports elementary functions.
 ///
 /// The `Math` protocol provides a suitable basis for writing functions that
-/// work on any real or complex floating-point type which provides the required
+/// work on any real or complex floating-point type that supports the required
 /// functions.
 public protocol Math : SignedNumeric {
   /// The mathematical constant pi (_π_).

--- a/Sources/PRNG.swift
+++ b/Sources/PRNG.swift
@@ -169,7 +169,7 @@ extension PRNG {
       bitCount == T.bitWidth {
       // It is an awkward way of spelling `next()`, but it is necessary.
       guard let next = first(where: { _ in true }) else { fatalError() }
-      return T(extendingOrTruncating: next)
+      return T(truncatingIfNeeded: next)
     }
 
     let (quotient, remainder) =
@@ -179,15 +179,14 @@ extension PRNG {
     // Call `next()` at least `quotient` times.
     for i in 0..<quotient {
       guard let next = first(where: { $0 <= max }) else { fatalError() }
-      temporary +=
-        T(extendingOrTruncating: next) &<< (randomBitWidth * i)
+      temporary += T(truncatingIfNeeded: next) &<< (randomBitWidth * i)
     }
     // If `remainder != 0`, call `next()` at least one more time.
     if remainder != 0 {
       guard let next = first(where: { $0 <= max }) else { fatalError() }
       let mask = Element.max &>> (Element.bitWidth - remainder)
       temporary +=
-        T(extendingOrTruncating: next & mask) &<< (randomBitWidth * quotient)
+        T(truncatingIfNeeded: next & mask) &<< (randomBitWidth * quotient)
     }
     return temporary
   }

--- a/Sources/Rational.swift
+++ b/Sources/Rational.swift
@@ -28,8 +28,8 @@
 /// print(a) // Prints "3/3"
 /// ```
 ///
-/// All arithmetic operations with values in canonical form (i.e. reduced to
-/// lowest terms) return results in canonical form. However, operations with
+/// All arithmetic operations on values in canonical form (i.e. reduced to
+/// lowest terms) return results in canonical form. However, operations on
 /// values not in canonical form may or may not return results that are
 /// themselves in canonical form. The property `canonicalized` is the canonical
 /// form of any value.

--- a/Sources/Rational.swift
+++ b/Sources/Rational.swift
@@ -55,7 +55,7 @@
 /// a value is NaN. `Rational<T>` arithmetic operations are intended to
 /// propagate NaN in the same manner as analogous floating-point operations.
 ///
-/// ### Fixed-Width Binary Parts
+/// ### Numerical Limits
 ///
 /// When a value of type `Rational<T>` is in canonical form, the sign of the
 /// numerator is the sign of the value; that is, in canonical form, the sign of

--- a/Sources/Real.swift
+++ b/Sources/Real.swift
@@ -11,10 +11,11 @@ import Glibc
 import Darwin.C
 #endif
 
-/// A floating-point type that provides a selection of special functions.
+/// A floating-point type that supports elementary functions and a selection of
+/// special functions.
 ///
 /// The `Real` protocol provides a suitable basis for writing functions that
-/// work on any floating-point type that provides the required functions.
+/// work on any floating-point type that supports the required functions.
 public protocol Real : Math, FloatingPoint {
   /// Returns the hypotenuse of a right-angle triangle with legs (catheti) of
   /// length `x` and `y`, preventing avoidable arithmetic overflow and

--- a/Tests/NumericAnnexTests/FactoringTests.swift
+++ b/Tests/NumericAnnexTests/FactoringTests.swift
@@ -11,7 +11,7 @@ class FactoringTests : XCTestCase {
     XCTAssertEqual(Int.gcd(24, 60), 12)
     XCTAssertEqual(Int.gcd(42, 56), 14)
 
-    XCTAssertTrue(Int8.gcdReportingOverflow(-128, -128).overflow == .overflow)
+    XCTAssertTrue(Int8.gcdReportingOverflow(-128, -128).overflow)
 
     // Test special values.
     XCTAssertEqual(UInt.gcd(0, 42), 42)
@@ -29,12 +29,12 @@ class FactoringTests : XCTestCase {
     XCTAssertEqual(Int8.lcmFullWidth(33, 48).high, 2)
     XCTAssertEqual(Int8.lcmFullWidth(33, 48).low, 16)
     XCTAssertEqual(Int8.lcmReportingOverflow(33, 48).partialValue, 16)
-    XCTAssertTrue(Int8.lcmReportingOverflow(33, 48).overflow == .overflow)
+    XCTAssertTrue(Int8.lcmReportingOverflow(33, 48).overflow)
 
     XCTAssertEqual(UInt8.lcmFullWidth(33, 48).high, 2)
     XCTAssertEqual(UInt8.lcmFullWidth(33, 48).low, 16)
     XCTAssertEqual(UInt8.lcmReportingOverflow(33, 48).partialValue, 16)
-    XCTAssertTrue(UInt8.lcmReportingOverflow(33, 48).overflow == .overflow)
+    XCTAssertTrue(UInt8.lcmReportingOverflow(33, 48).overflow)
 
     // Test special values.
     XCTAssertEqual(UInt.lcm(0, 42), 0)
@@ -44,32 +44,32 @@ class FactoringTests : XCTestCase {
     XCTAssertEqual(Int8.lcmFullWidth(0, 42).high, 0)
     XCTAssertEqual(Int8.lcmFullWidth(0, 42).low, 0)
     XCTAssertEqual(Int8.lcmReportingOverflow(0, 42).partialValue, 0)
-    XCTAssertTrue(Int8.lcmReportingOverflow(0, 42).overflow == .none)
+    XCTAssertFalse(Int8.lcmReportingOverflow(0, 42).overflow)
 
     XCTAssertEqual(Int8.lcmFullWidth(42, 0).high, 0)
     XCTAssertEqual(Int8.lcmFullWidth(42, 0).low, 0)
     XCTAssertEqual(Int8.lcmReportingOverflow(42, 0).partialValue, 0)
-    XCTAssertTrue(Int8.lcmReportingOverflow(42, 0).overflow == .none)
+    XCTAssertFalse(Int8.lcmReportingOverflow(42, 0).overflow)
 
     XCTAssertEqual(Int8.lcmFullWidth(0, 0).high, 0)
     XCTAssertEqual(Int8.lcmFullWidth(0, 0).low, 0)
     XCTAssertEqual(Int8.lcmReportingOverflow(0, 0).partialValue, 0)
-    XCTAssertTrue(Int8.lcmReportingOverflow(0, 0).overflow == .none)
+    XCTAssertFalse(Int8.lcmReportingOverflow(0, 0).overflow)
 
     XCTAssertEqual(UInt8.lcmFullWidth(0, 42).high, 0)
     XCTAssertEqual(UInt8.lcmFullWidth(0, 42).low, 0)
     XCTAssertEqual(UInt8.lcmReportingOverflow(0, 42).partialValue, 0)
-    XCTAssertTrue(UInt8.lcmReportingOverflow(0, 42).overflow == .none)
+    XCTAssertFalse(UInt8.lcmReportingOverflow(0, 42).overflow)
 
     XCTAssertEqual(UInt8.lcmFullWidth(42, 0).high, 0)
     XCTAssertEqual(UInt8.lcmFullWidth(42, 0).low, 0)
     XCTAssertEqual(UInt8.lcmReportingOverflow(42, 0).partialValue, 0)
-    XCTAssertTrue(UInt8.lcmReportingOverflow(42, 0).overflow == .none)
+    XCTAssertFalse(UInt8.lcmReportingOverflow(42, 0).overflow)
 
     XCTAssertEqual(UInt8.lcmFullWidth(0, 0).high, 0)
     XCTAssertEqual(UInt8.lcmFullWidth(0, 0).low, 0)
     XCTAssertEqual(UInt8.lcmReportingOverflow(0, 0).partialValue, 0)
-    XCTAssertTrue(UInt8.lcmReportingOverflow(0, 0).overflow == .none)
+    XCTAssertFalse(UInt8.lcmReportingOverflow(0, 0).overflow)
   }
 
   static var allTests = [


### PR DESCRIPTION
This PR updates generic algorithms to match recent revisions to the standard library. The changes, specifically, are:

* The initializer `.init(extendingOrTruncating:)` is now `.init(truncatingIfNeeded:)`
* `ArithmeticOverflow` is abolished
* Smart shifts and binary shifts are reorganized

Some trivial changes to a doc comment are incidentally included in this PR.

_This PR will not pass CI testing until the next beta release of XCode and should not be merged until that time._